### PR TITLE
Add netbsd to conditional compilation for keepalive

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -542,7 +542,7 @@ impl<T: AsRawSocket> AsSock for T {
 cfg_if! {
     if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         use libc::TCP_KEEPALIVE as KEEPALIVE_OPTION;
-    } else if #[cfg(target_os="openbsd")] {
+    } else if #[cfg(any(target_os = "openbsd", target_os = "netbsd"))] {
         use libc::SO_KEEPALIVE as KEEPALIVE_OPTION;
     } else if #[cfg(unix)] {
         use libc::TCP_KEEPIDLE as KEEPALIVE_OPTION;


### PR DESCRIPTION
Just a small tweak to allow netbsd targets to compile correctly
