### PR TITLE
Disable the `unix` module on Android.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "net2"
-version = "0.2.18"
+version = "0.2.19"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ mod utils;
 
 #[cfg(unix)] #[path = "sys/unix/mod.rs"] mod sys;
 #[cfg(windows)] #[path = "sys/windows/mod.rs"] mod sys;
-#[cfg(unix)] pub mod unix;
+#[cfg(all(unix, not(target_os = "android")))] pub mod unix;
 
 pub use tcp::TcpBuilder;
 pub use udp::UdpBuilder;


### PR DESCRIPTION
The only methods it defines require `libc::SO_REUSEPORT`, which current versions on the libc crate do not provide for Android targets.

This is a temporary work around to make this crate build at all on Android. It should be reverted when https://github.com/rust-lang-nursery/libc/pull/70 lands.

This not a breaking change since the crate did not build at all before.

CC https://github.com/servo/servo/pull/8446
