### PR TITLE
Fixed regression in ip2in6_addr from a93484d

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -976,22 +976,22 @@ fn ip2in6_addr(ip: &Ipv6Addr) -> in6_addr {
     let mut ret: in6_addr = unsafe { mem::zeroed() };
     let seg = ip.segments();
     ret.s6_addr = [
-        (seg[0] >> 0) as u8,
         (seg[0] >> 8) as u8,
-        (seg[1] >> 0) as u8,
+        (seg[0] >> 0) as u8,
         (seg[1] >> 8) as u8,
-        (seg[2] >> 0) as u8,
+        (seg[1] >> 0) as u8,
         (seg[2] >> 8) as u8,
-        (seg[3] >> 0) as u8,
+        (seg[2] >> 0) as u8,
         (seg[3] >> 8) as u8,
-        (seg[4] >> 0) as u8,
+        (seg[3] >> 0) as u8,
         (seg[4] >> 8) as u8,
-        (seg[5] >> 0) as u8,
+        (seg[4] >> 0) as u8,
         (seg[5] >> 8) as u8,
-        (seg[6] >> 0) as u8,
+        (seg[5] >> 0) as u8,
         (seg[6] >> 8) as u8,
-        (seg[7] >> 0) as u8,
+        (seg[6] >> 0) as u8,
         (seg[7] >> 8) as u8,
+        (seg[7] >> 0) as u8,
     ];
     return ret
 }


### PR DESCRIPTION
a93484d removed the dependency to libc and tried to replace hton(), but did so incorrectly.
The correct memory layout (network order) can be seen here: https://msdn.microsoft.com/en-us/library/ee175867.aspx as well as reference code here: https://github.com/libuv/libuv/blob/a59085e140d52076960fd2ee84875577378abc62/src/inet.c#L267

_This incorrect code leads to all sorts of problems with IPv6 and makes using it almost impossible._ This behaviour can for instance easily be seen on Windows by using the following code (using mio):

``` rust
extern crate mio;

fn main() {
    let v4_local = "0.0.0.0:48879".parse().unwrap();
    let v4_multi: mio::IpAddr = "227.1.1.100".parse().unwrap();

    let v4 = mio::udp::UdpSocket::v4().unwrap();

    println!("v4 A");
    v4.bind(&v4_local).unwrap();
    println!("v4 B");
    v4.join_multicast(&v4_multi).unwrap();
    println!("v4 C");


    let v6_local = "[::]:48879".parse().unwrap();
    let v6_multi: mio::IpAddr = "ff02::300".parse().unwrap();

    let v6 = mio::udp::UdpSocket::v6().unwrap();

    println!("v6 A");
    v6.bind(&v6_local).unwrap();
    println!("v6 B");
    v6.join_multicast(&v6_multi).unwrap();
    println!("v6 C");
}
```

Windows will outright reject the `v6_multi` address and throw a "WSAEADDRNOTAVAIL"/code=10049 error in the `join_multicast()` method.

If you dump the memory of `ret` in `ip2in6_addr` using `x/16xb &ret`, you will see that the memory looks like this:

```
0xfff558: 0x02 0xff 0x00 0x00 0x00 0x00 0x00 0x00
0xfff560: 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x03
```

which is obviously incorrect since network byte order (big endian) places the most significant byte at the lowest address and so on.
