### PR TITLE
separated windows and unix deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,16 @@ description = """
 Extensions to the standard library's networking types as proposed in RFC 1158.
 """
 
-[dependencies]
-libc = "0.2.6"
+[target.'cfg(windows)'.dependencies]
 ws2_32-sys = "0.2"
 winapi = "0.2"
 kernel32-sys = "0.2"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.6"
+
+[dependencies]
+openssl = "0.7.10"
 cfg-if = "0.1"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,10 +41,13 @@
        html_root_url = "https://doc.rust-lang.org/net2-rs")]
 #![deny(missing_docs, warnings)]
 
-extern crate kernel32;
-extern crate libc;
-extern crate winapi;
-extern crate ws2_32;
+
+#[cfg(unix)] extern crate libc;
+
+#[cfg(windows)] extern crate kernel32;
+#[cfg(windows)] extern crate winapi;
+#[cfg(windows)] extern crate ws2_32;
+
 #[macro_use] extern crate cfg_if;
 
 use std::io;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -10,6 +10,7 @@
 
 #![allow(bad_style)]
 
+
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,7 +1,7 @@
 //! Unix-specific extensions to the `std::net` types.
 
 use std::io;
-use libc::{self, c_int};
+use sys::c::{self, c_int};
 
 use {TcpBuilder, UdpBuilder};
 use ext::{self, AsSock};
@@ -18,7 +18,7 @@ pub trait UnixTcpBuilderExt {
 
 impl UnixTcpBuilderExt for TcpBuilder {
     fn reuse_port(&self, reuse: bool) -> io::Result<&Self> {
-        ext::set_opt(self.as_sock(), libc::SOL_SOCKET, libc::SO_REUSEPORT,
+        ext::set_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT,
                     reuse as c_int).map(|()| self)
     }
 }
@@ -35,7 +35,7 @@ pub trait UnixUdpBuilderExt {
 
 impl UnixUdpBuilderExt for UdpBuilder {
     fn reuse_port(&self, reuse: bool) -> io::Result<&Self> {
-        ext::set_opt(self.as_sock(), libc::SOL_SOCKET, libc::SO_REUSEPORT,
+        ext::set_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT,
                     reuse as c_int).map(|()| self)
     }
 }


### PR DESCRIPTION
This is a minor but potentially controversial change. 

I was housekeeping in mio and separated out windows and linux dependencies, so than when building on one, it would not attempt to retrieve/build the other. 

https://github.com/carllerche/mio/pull/382 

The net2-rs dependency was one that needed segretation.  I'm sure none of this will matter when net2 becomes part of std::, but I don't know when that will be. 
