### PR TITLE
Fix compilation on Illumos/Solaris

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -25,7 +25,8 @@ cfg_if! {
                  target_os = "ios",
                  target_os = "macos",
                  target_os = "netbsd",
-                 target_os = "openbsd"))] {
+                 target_os = "openbsd",
+                 target_os = "solaris"))] {
         use libc::IPV6_JOIN_GROUP as IPV6_ADD_MEMBERSHIP;
         use libc::IPV6_LEAVE_GROUP as IPV6_DROP_MEMBERSHIP;
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ mod utils;
 #[cfg(windows)] #[path = "sys/windows/mod.rs"] mod sys;
 // FIXME: should include android here once SO_REUSEPORT has been fixed in
 //        liblibc on android
-#[cfg(all(unix, not(target_os = "android")))] pub mod unix;
+#[cfg(all(unix, not(any(target_os = "android", target_os = "solaris"))))] pub mod unix;
 
 pub use tcp::TcpBuilder;
 pub use udp::UdpBuilder;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -13,7 +13,9 @@ use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::os::unix::io::FromRawFd;
-use libc::{self, c_int, ioctl, FIOCLEX};
+use libc::{self, c_int};
+#[cfg(not(target_os = "solaris"))]
+use libc::{ioctl, FIOCLEX};
 
 mod impls;
 
@@ -26,10 +28,22 @@ pub struct Socket {
 }
 
 impl Socket {
+    #[cfg(not(target_os = "solaris"))]
     pub fn new(family: c_int, ty: c_int) -> io::Result<Socket> {
         unsafe {
             let fd = try!(::cvt(libc::socket(family, ty, 0)));
             ioctl(fd, FIOCLEX);
+            Ok(Socket { fd: fd })
+        }
+    }
+
+    // ioctl(FIOCLEX) is not supported by Solaris/Illumos,
+    // use fcntl(FD_CLOEXEC) instead
+    #[cfg(target_os = "solaris")]
+    pub fn new(family: c_int, ty: c_int) -> io::Result<Socket> {
+        unsafe {
+            let fd = try!(::cvt(libc::socket(family, ty, 0)));
+            libc::fcntl(fd, libc::FD_CLOEXEC);
             Ok(Socket { fd: fd })
         }
     }


### PR DESCRIPTION
This pull request fixes the following issues that prevent successful compilation on Solaris:
- FIOCLEX fd flag is not supported, FD_CLOEXEC should be used instead.
- SO_REUSEPORT is not supported.

Please let me know if the code formatting should be changed.

Thanks!
