### PR TITLE
Introduce connect_w_timeout for TcpBuilder

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -345,7 +345,7 @@ pub trait TcpListenerExt {
     ///
     /// [link]: trait.TcpStreamExt.html#tymethod.set_nonblocking
     fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()>;
-    
+
     /// Sets the linger duration of this socket by setting the SO_LINGER option
     #[cfg(any(feature = "nightly", feature = "duration"))]
     fn set_linger(&self, dur: Option<Duration>) -> io::Result<()>;
@@ -810,7 +810,7 @@ impl TcpStreamExt for TcpStream {
     fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         set_nonblocking(self.as_sock(), nonblocking)
     }
-    
+
     #[cfg(any(feature = "nightly", feature = "duration"))]
     fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
         set_opt(self.as_sock(), SOL_SOCKET, SO_LINGER, dur2linger(dur))
@@ -818,7 +818,7 @@ impl TcpStreamExt for TcpStream {
 
     #[cfg(any(feature = "nightly", feature = "duration"))]
     fn linger(&self) -> io::Result<Option<Duration>> {
-        get_opt(self.as_sock(), SOL_SOCKET, SO_LINGER).map(linger2dur)        
+        get_opt(self.as_sock(), SOL_SOCKET, SO_LINGER).map(linger2dur)
     }
 }
 
@@ -1128,7 +1128,7 @@ fn do_connect<A: ToSocketAddrs>(sock: Socket, addr: A) -> io::Result<()> {
 }
 
 #[cfg(unix)]
-fn set_nonblocking(sock: Socket, nonblocking: bool) -> io::Result<()> {
+pub fn set_nonblocking(sock: Socket, nonblocking: bool) -> io::Result<()> {
     let mut nonblocking = nonblocking as c_ulong;
     ::cvt(unsafe {
         ioctl(sock, FIONBIO, &mut nonblocking)
@@ -1136,7 +1136,7 @@ fn set_nonblocking(sock: Socket, nonblocking: bool) -> io::Result<()> {
 }
 
 #[cfg(windows)]
-fn set_nonblocking(sock: Socket, nonblocking: bool) -> io::Result<()> {
+pub fn set_nonblocking(sock: Socket, nonblocking: bool) -> io::Result<()> {
     let mut nonblocking = nonblocking as c_ulong;
     ::cvt(unsafe {
         ioctlsocket(sock, FIONBIO as c_int, &mut nonblocking)
@@ -1232,7 +1232,7 @@ impl TcpListenerExt for TcpListener {
 
     #[cfg(any(feature = "nightly", feature = "duration"))]
     fn linger(&self) -> io::Result<Option<Duration>> {
-        get_opt(self.as_sock(), SOL_SOCKET, SO_LINGER).map(linger2dur)        
+        get_opt(self.as_sock(), SOL_SOCKET, SO_LINGER).map(linger2dur)
     }
 }
 
@@ -1290,7 +1290,7 @@ impl TcpBuilder {
     /// Gets the linger option for this socket
     #[cfg(any(feature = "nightly", feature = "duration"))]
     fn linger(&self) -> io::Result<Option<Duration>> {
-        get_opt(self.as_sock(), SOL_SOCKET, SO_LINGER).map(linger2dur)        
+        get_opt(self.as_sock(), SOL_SOCKET, SO_LINGER).map(linger2dur)
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -8,6 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use std::ptr;
 use std::fmt;
 use std::io;
 use std::mem;
@@ -48,6 +49,59 @@ impl Socket {
             ::cvt(c::connect(self.inner.raw(), addr, len)).map(|_| ())
         }
     }
+
+    pub fn connect_w_timeout(&self, addr: &SocketAddr, ms: u64) -> io::Result<()> {
+        unsafe {
+            let mut self_fd_set: c::fd_set = mem::zeroed();
+            fd_set(self, &mut self_fd_set);
+
+            #[cfg(unix)]
+            let nfds = self.inner.raw() + 1;
+            //First argument is ignored in winsock select()
+            #[cfg(windows)]
+            let nfds = 0;
+
+            #[cfg(windows)]
+            let timeout = c::timeval {
+                tv_sec: ms as c::c_long / 1000,
+                tv_usec: (ms as c::c_long % 1000) * 1000
+            };
+            #[cfg(windows)]
+            let timeout = &timeout as *const c::timeval;
+            #[cfg(unix)]
+            let mut timeout = c::timeval {
+                tv_sec: ms as c::time_t / 1000,
+                tv_usec: (ms as c::suseconds_t % 1000) * 1000
+            };
+            #[cfg(unix)]
+            let timeout = &mut timeout as *mut c::timeval;
+
+            try!(::ext::set_nonblocking(self.inner.raw(), true));
+
+            //In most cases connect should return would_block.
+            //Unclear if immediate success is actually possible.
+            let result = self.connect(addr);
+            match result {
+                Ok(_) => (),
+                Err(error) => {
+                    //it is safe as error constructed from last_os_error()
+                    if error.raw_os_error().unwrap() != c::CONN_WOULD_BLOCK as i32 {
+                        return Err(error);
+                    }
+                }
+            }
+
+            let result = try!(::cvt(c::select(nfds, ptr::null_mut(), &mut self_fd_set, &mut self_fd_set, timeout)));
+
+            try!(::ext::set_nonblocking(self.inner.raw(), false));
+            if result == 0 {
+                Err(io::Error::new(io::ErrorKind::TimedOut, "Connection timed out"))
+            }
+            else {
+                Ok(())
+            }
+        }
+    }
 }
 
 impl fmt::Debug for Socket {
@@ -80,6 +134,24 @@ fn addr2raw(addr: &SocketAddr) -> (*const c::sockaddr, c::socklen_t) {
         }
         SocketAddr::V6(ref a) => {
             (a as *const _ as *const _, mem::size_of_val(a) as c::socklen_t)
+        }
+    }
+}
+
+#[cfg(unix)]
+fn fd_set(socket: &Socket, fd_set: *mut c::fd_set) {
+    unsafe { c::FD_SET(socket.inner.raw(), fd_set) };
+}
+
+#[cfg(windows)]
+fn fd_set(socket: &Socket, fd_set: *mut c::fd_set) {
+    let mut fd_set = unsafe { &mut *fd_set };
+
+    for idx in 0..c::FD_SETSIZE {
+        if fd_set.fd_array[idx] == 0 {
+            fd_set.fd_array[idx] = socket.inner.raw();
+            fd_set.fd_count += 1;
+            break;
         }
     }
 }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -21,6 +21,7 @@ mod impls;
 
 pub mod c {
     pub use libc::*;
+    pub const CONN_WOULD_BLOCK: c_int = EINPROGRESS;
 }
 
 pub struct Socket {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -29,6 +29,7 @@ pub mod c {
     pub use ws2_32::*;
 
     pub use winapi::SOCKADDR as sockaddr;
+    pub const CONN_WOULD_BLOCK: DWORD = WSAEWOULDBLOCK;
 }
 
 mod impls;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -93,6 +93,23 @@ impl TcpBuilder {
         })
     }
 
+    /// Initiate a connection on this socket toward the specified address.
+    ///
+    /// This function allows additionaly to specify timeout for connect.
+    pub fn connect_w_timeout<T>(&self, addr: T, ms: u64) -> io::Result<TcpStream>
+        where T: ToSocketAddrs
+    {
+        self.with_socket(|sock| {
+            let err = io::Error::new(io::ErrorKind::Other,
+                                     "no socket addresses resolved");
+            try!(addr.to_socket_addrs()).fold(Err(err), |prev, addr| {
+                prev.or_else(|_| sock.connect_w_timeout(&addr, ms))
+            })
+        }).and_then(|()| {
+            self.to_tcp_stream()
+        })
+    }
+
     /// Converts this builder into a `TcpStream`
     ///
     /// This function will consume the internal socket and return it re-wrapped

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -3,6 +3,7 @@ extern crate net2;
 use std::net::TcpStream;
 use std::io::prelude::*;
 use std::thread;
+use std::time;
 
 use net2::TcpBuilder;
 
@@ -31,4 +32,46 @@ fn smoke_build_listener() {
     let mut stream = t!(TcpStream::connect(&addr));
     t!(stream.write(&[1,2,3]));
     t.join().unwrap();
+}
+
+#[test]
+fn tcp_connect_w_timeout_fail() {
+    let timeout = 100;
+
+    let client = t!(TcpBuilder::new_v4());
+
+    let now = time::Instant::now();
+    let result = client.connect_w_timeout("192.192.192.192:1", timeout);
+    let elapsed = now.elapsed();
+
+    assert!(result.is_err());
+    let result = result.err().unwrap();
+    assert_eq!(result.kind(), std::io::ErrorKind::TimedOut);
+    let elapsed = elapsed.as_secs() / 1000 + elapsed.subsec_nanos() as u64 / 1000000;
+    assert!(elapsed >= (timeout - 1) || elapsed <= (timeout + 1));
+}
+
+#[test]
+fn tcp_connect_w_timeout_success() {
+    let timeout = 0;
+
+    let server = t!(TcpBuilder::new_v4());
+    t!(server.bind("127.0.0.1:0"));
+    let server = t!(server.listen(500));
+
+    let addr = t!(server.local_addr());
+
+    let t = thread::spawn(move || {
+        let mut s = t!(server.accept()).0;
+        let mut b = [0; 4];
+        t!(s.read(&mut b));
+        assert_eq!(b, [1, 2, 3, 0]);
+    });
+
+    let client = t!(TcpBuilder::new_v4());
+
+    let mut stream = t!(client.connect_w_timeout(&addr, timeout));
+    t!(stream.write(&[1,2,3]));
+    t.join().unwrap();
+
 }


### PR DESCRIPTION
Subj is draft for my proposal to introduce connect with timeout.
It should allow user to control how long to wait for connection instead of having just default timeout.

* [ ] Is it needed?
    * Allows user to configure timeout instead of using default. On windows default timeout can be relatively BIG.
* [ ] What type of timeout should be allowed to set? seconds or maybe microseconds?
* [ ] Should it be added to UdpBuilder, alongside with just `connect`?