### PR TITLE
Add local_addr method to TcpBuilder #26

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,8 @@ fn cvt_win<T: PartialEq + utils::Zero>(t: T) -> io::Result<T> {
 
 fn hton<I: NetInt>(i: I) -> I { i.to_be() }
 
+fn ntoh<I: NetInt>(i: I) -> I { I::from_be(i) }
+
 trait AsInner {
     type Inner;
     fn as_inner(&self) -> &Self::Inner;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -101,7 +101,7 @@ fn raw2addr(storage: &c::sockaddr_storage, len: c::socklen_t) -> io::Result<Sock
             unsafe {
                 assert!(len as usize >= mem::size_of::<c::sockaddr_in>());
                 let sa = storage as *const _ as *const c::sockaddr_in;
-                let bits = ::ntoh((*sa).sin_addr.s_addr);
+                let bits = c::sockaddr_in_u32(&(*sa));
                 let ip = Ipv4Addr::new((bits >> 24) as u8,
                                        (bits >> 16) as u8,
                                        (bits >> 8) as u8,

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -21,6 +21,10 @@ mod impls;
 
 pub mod c {
     pub use libc::*;
+
+    pub fn sockaddr_in_u32(sa: &sockaddr_in) -> u32 {
+        ::ntoh((*sa).sin_addr.s_addr)
+    }
 }
 
 pub struct Socket {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -24,10 +24,42 @@ const WSA_FLAG_OVERLAPPED: DWORD = 0x01;
 const HANDLE_FLAG_INHERIT: DWORD = 0x00000001;
 
 pub mod c {
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct in_addr {
+        pub s_addr: u32,
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct in6_addr {
+        pub s6_addr: [u8; 16],
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct sockaddr_in {
+        pub sin_family: ADDRESS_FAMILY,
+        pub sin_port: USHORT,
+        pub sin_addr: in_addr,
+        pub sin_zero: [CHAR; 8],
+    }
+
+    #[repr(C)]
+    #[derive(Copy, Clone)]
+    pub struct sockaddr_in6 {
+        pub sin6_family: ADDRESS_FAMILY,
+        pub sin6_port: USHORT,
+        pub sin6_flowinfo: c_ulong,
+        pub sin6_addr: in6_addr,
+        pub sin6_scope_id: c_ulong,
+    }
+
     pub use winapi::*;
     pub use ws2_32::*;
 
     pub use winapi::SOCKADDR as sockaddr;
+    pub use winapi::SOCKADDR_STORAGE as sockaddr_storage;
 }
 
 mod impls;

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -24,42 +24,16 @@ const WSA_FLAG_OVERLAPPED: DWORD = 0x01;
 const HANDLE_FLAG_INHERIT: DWORD = 0x00000001;
 
 pub mod c {
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub struct in_addr {
-        pub s_addr: u32,
-    }
-
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub struct in6_addr {
-        pub s6_addr: [u8; 16],
-    }
-
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in {
-        pub sin_family: ADDRESS_FAMILY,
-        pub sin_port: USHORT,
-        pub sin_addr: in_addr,
-        pub sin_zero: [CHAR; 8],
-    }
-
-    #[repr(C)]
-    #[derive(Copy, Clone)]
-    pub struct sockaddr_in6 {
-        pub sin6_family: ADDRESS_FAMILY,
-        pub sin6_port: USHORT,
-        pub sin6_flowinfo: c_ulong,
-        pub sin6_addr: in6_addr,
-        pub sin6_scope_id: c_ulong,
-    }
-
     pub use winapi::*;
     pub use ws2_32::*;
 
     pub use winapi::SOCKADDR as sockaddr;
     pub use winapi::SOCKADDR_STORAGE as sockaddr_storage;
+    pub use winapi::SOCKADDR_IN as sockaddr_in;
+
+    pub fn sockaddr_in_u32(sa: &sockaddr_in) -> u32 {
+        ::ntoh(sa.sin_addr.S_un)
+    }
 }
 
 mod impls;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -10,7 +10,7 @@
 
 use std::cell::RefCell;
 use std::io;
-use std::net::{ToSocketAddrs, TcpListener, TcpStream};
+use std::net::{SocketAddr, ToSocketAddrs, TcpListener, TcpStream};
 use std::fmt;
 
 use IntoInner;
@@ -116,6 +116,18 @@ impl TcpBuilder {
             .map(|s| s.into_inner().into_tcp_listener())
             .ok_or(io::Error::new(io::ErrorKind::Other,
                                   "socket has already been consumed"))
+    }
+
+    /// Returns the address of the local half of this TCP socket.
+    ///
+    /// An error will be returned if `listen` or `connect` has already been
+    /// called on this builder.
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
+        match *self.socket.borrow() {
+            Some(ref s) => s.getsockname(),
+            None => Err(io::Error::new(io::ErrorKind::Other,
+                                       "builder has already finished its socket")),
+        }
     }
 
     fn with_socket<F>(&self, f: F) -> io::Result<()>

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1,6 +1,6 @@
 extern crate net2;
 
-use std::net::TcpStream;
+use std::net::{TcpStream, IpAddr, Ipv4Addr, Ipv6Addr};
 use std::io::prelude::*;
 use std::thread;
 
@@ -17,9 +17,11 @@ macro_rules! t {
 fn smoke_build_listener() {
     let b = t!(TcpBuilder::new_v4());
     t!(b.bind("127.0.0.1:0"));
-    let listener = t!(b.listen(200));
 
-    let addr = t!(listener.local_addr());
+    let addr = t!(b.local_addr());
+    assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+
+    let listener = t!(b.listen(200));
 
     let t = thread::spawn(move || {
         let mut s = t!(listener.accept()).0;
@@ -31,4 +33,13 @@ fn smoke_build_listener() {
     let mut stream = t!(TcpStream::connect(&addr));
     t!(stream.write(&[1,2,3]));
     t.join().unwrap();
+}
+
+#[test]
+fn smoke_build_listener_v6() {
+    let b = t!(TcpBuilder::new_v6());
+    t!(b.bind("::1:0"));
+
+    let addr = t!(b.local_addr());
+    assert_eq!(addr.ip(), IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)));
 }


### PR DESCRIPTION
This PR implements a feature requested in #26.

I'm not quite sure about the Windows part of the implementation but I haven't found a better way to do that. Besides, AFAIK, in [libstd it's implemented](https://github.com/rust-lang/rust/blob/1.15.1/src/libstd/sys/windows/c.rs#L783) in a similar way.