### PR TITLE
migrate to winapi 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - nightly
 sudo: false
 before_script:
-  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+  - pip2 install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - if [ "$TRAVIS_RUST_VERSION" = "1.1.0" ]; then
       cargo test --no-default-features;

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,7 @@ Extensions to the standard library's networking types as proposed in RFC 1158.
 """
 
 [target."cfg(windows)".dependencies]
-ws2_32-sys = "0.2"
-winapi = "0.2"
-kernel32-sys = "0.2"
+winapi = { version = "0.3", features = ["handleapi", "winsock2", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.16"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,7 @@
 
 #[cfg(unix)] extern crate libc;
 
-#[cfg(windows)] extern crate kernel32;
 #[cfg(windows)] extern crate winapi;
-#[cfg(windows)] extern crate ws2_32;
 
 #[macro_use] extern crate cfg_if;
 

--- a/src/sys/windows/impls.rs
+++ b/src/sys/windows/impls.rs
@@ -8,37 +8,37 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::windows::io::{FromRawSocket, AsRawSocket};
-use winapi::SOCKET;
+use std::os::windows::io::{FromRawSocket, RawSocket, AsRawSocket};
+use winapi::um::winsock2::SOCKET;
 
 use {TcpBuilder, UdpBuilder, FromInner, AsInner};
 use socket::Socket;
 use sys;
 
 impl FromRawSocket for TcpBuilder {
-    unsafe fn from_raw_socket(fd: SOCKET) -> TcpBuilder {
-        let sock = sys::Socket::from_inner(fd);
+    unsafe fn from_raw_socket(fd: RawSocket) -> TcpBuilder {
+        let sock = sys::Socket::from_inner(fd as SOCKET);
         TcpBuilder::from_inner(Socket::from_inner(sock))
     }
 }
 
 impl AsRawSocket for TcpBuilder {
-    fn as_raw_socket(&self) -> SOCKET {
+    fn as_raw_socket(&self) -> RawSocket {
         // TODO: this unwrap() is very bad
-        self.as_inner().borrow().as_ref().unwrap().as_inner().raw()
+        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as RawSocket
     }
 }
 
 impl FromRawSocket for UdpBuilder {
-    unsafe fn from_raw_socket(fd: SOCKET) -> UdpBuilder {
-        let sock = sys::Socket::from_inner(fd);
+    unsafe fn from_raw_socket(fd: RawSocket) -> UdpBuilder {
+        let sock = sys::Socket::from_inner(fd as SOCKET);
         UdpBuilder::from_inner(Socket::from_inner(sock))
     }
 }
 
 impl AsRawSocket for UdpBuilder {
-    fn as_raw_socket(&self) -> SOCKET {
+    fn as_raw_socket(&self) -> RawSocket {
         // TODO: this unwrap() is very bad
-        self.as_inner().borrow().as_ref().unwrap().as_inner().raw()
+        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as RawSocket
     }
 }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -13,28 +13,38 @@
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
-use std::os::windows::io::FromRawSocket;
+use std::os::windows::io::{RawSocket, FromRawSocket};
 use std::sync::{Once, ONCE_INIT};
 
-use winapi::*;
-use ws2_32::*;
-use kernel32::*;
-
-const WSA_FLAG_OVERLAPPED: DWORD = 0x01;
 const HANDLE_FLAG_INHERIT: DWORD = 0x00000001;
 
 pub mod c {
-    pub use winapi::*;
-    pub use ws2_32::*;
-
-    pub use winapi::SOCKADDR as sockaddr;
-    pub use winapi::SOCKADDR_STORAGE as sockaddr_storage;
-    pub use winapi::SOCKADDR_IN as sockaddr_in;
+    pub use winapi::ctypes::*;
+    pub use winapi::um::handleapi::*;
+    pub use winapi::um::winbase::*;
+    pub use winapi::um::winsock2::*;
+    pub use winapi::um::ws2tcpip::*;
+    
+    pub use winapi::shared::inaddr::*;
+    pub use winapi::shared::in6addr::*;
+    pub use winapi::shared::minwindef::*;
+    pub use winapi::shared::ntdef::*;
+    pub use winapi::shared::ws2def::*;
+    pub use winapi::shared::ws2def::{SOCK_STREAM, SOCK_DGRAM};
+    pub use winapi::shared::ws2def::SOCKADDR as sockaddr;
+    pub use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
+    pub use winapi::shared::ws2def::SOCKADDR_IN as sockaddr_in;
+    pub use winapi::shared::ws2ipdef::*;
+    pub use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH as sockaddr_in6;
+    pub use winapi::shared::ws2ipdef::IP_MREQ as ip_mreq;
+    pub use winapi::shared::ws2ipdef::IPV6_MREQ as ipv6_mreq;
 
     pub fn sockaddr_in_u32(sa: &sockaddr_in) -> u32 {
-        ::ntoh(sa.sin_addr.S_un)
+        ::ntoh(unsafe { *sa.sin_addr.S_un.S_addr() })
     }
 }
+
+use self::c::*;
 
 mod impls;
 
@@ -76,15 +86,15 @@ impl Socket {
     }
 
     pub fn into_tcp_listener(self) -> TcpListener {
-        unsafe { TcpListener::from_raw_socket(self.into_socket()) }
+        unsafe { TcpListener::from_raw_socket(self.into_socket() as RawSocket) }
     }
 
     pub fn into_tcp_stream(self) -> TcpStream {
-        unsafe { TcpStream::from_raw_socket(self.into_socket()) }
+        unsafe { TcpStream::from_raw_socket(self.into_socket() as RawSocket) }
     }
 
     pub fn into_udp_socket(self) -> UdpSocket {
-        unsafe { UdpSocket::from_raw_socket(self.into_socket()) }
+        unsafe { UdpSocket::from_raw_socket(self.into_socket() as RawSocket) }
     }
 
     fn set_no_inherit(&self) -> io::Result<()> {


### PR DESCRIPTION
This cannot land until a new winapi version is released, since a missing type is not included in the current version (sockaddr_in6).

