### PR TITLE
Add additional multicast options to UDP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,17 +15,17 @@ Extensions to the standard library's networking types as proposed in RFC 1158.
 winapi = { version = "0.3", features = ["handleapi", "winsock2", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.16"
+libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
 
 # Compat with older Cargo versions temporarily
 [target.x86_64-unknown-linux-gnu.dependencies]
-libc = "0.2.16"
+libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
 [target.i686-unknown-linux-gnu.dependencies]
-libc = "0.2.16"
+libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
 [target.x86_64-apple-darwin.dependencies]
-libc = "0.2.16"
+libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
 [target.i686-apple-darwin.dependencies]
-libc = "0.2.16"
+libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
 
 [dependencies]
 cfg-if = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "net2"
-version = "0.2.31"
+version = "0.2.32"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -15,17 +15,17 @@ Extensions to the standard library's networking types as proposed in RFC 1158.
 winapi = { version = "0.3", features = ["handleapi", "winsock2", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 [target."cfg(unix)".dependencies]
-libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
+libc = "0.2.37"
 
 # Compat with older Cargo versions temporarily
 [target.x86_64-unknown-linux-gnu.dependencies]
-libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
+libc = "0.2.37"
 [target.i686-unknown-linux-gnu.dependencies]
-libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
+libc = "0.2.37"
 [target.x86_64-apple-darwin.dependencies]
-libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
+libc = "0.2.37"
 [target.i686-apple-darwin.dependencies]
-libc = { version = "0.2.16", git = "https://github.com/bluejekyll/libc" }
+libc = "0.2.37"
 
 [dependencies]
 cfg-if = "0.1"

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -17,6 +17,7 @@ use std::net::ToSocketAddrs;
 
 use {TcpBuilder, UdpBuilder, FromInner};
 use sys;
+use sys::c;
 use socket;
 
 cfg_if! {
@@ -1180,18 +1181,6 @@ fn ip2in_addr(ip: &Ipv4Addr) -> in_addr {
     }
 }
 
-#[cfg(unix)]
-fn in_addr2ip(ip: &in_addr) -> Ipv4Addr {
-    let h_addr = ::ntoh(ip.s_addr);
-    
-    let a: u8 = (h_addr >> 24) as u8;
-    let b: u8 = (h_addr >> 16) as u8;
-    let c: u8 = (h_addr >> 8) as u8;
-    let d: u8 = (h_addr >> 0) as u8;
-
-    Ipv4Addr::new(a,b,c,d)
-}
-
 #[cfg(windows)]
 fn ip2in_addr(ip: &Ipv4Addr) -> in_addr {
     let oct = ip.octets();
@@ -1205,6 +1194,17 @@ fn ip2in_addr(ip: &Ipv4Addr) -> in_addr {
             S_un: S_un,
         }
     }
+}
+
+fn in_addr2ip(ip: &in_addr) -> Ipv4Addr {
+    let h_addr = c::in_addr_to_u32(ip);
+    
+    let a: u8 = (h_addr >> 24) as u8;
+    let b: u8 = (h_addr >> 16) as u8;
+    let c: u8 = (h_addr >> 8) as u8;
+    let d: u8 = (h_addr >> 0) as u8;
+
+    Ipv4Addr::new(a,b,c,d)
 }
 
 #[cfg(target_os = "android")]

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -25,6 +25,10 @@ pub mod c {
     pub fn sockaddr_in_u32(sa: &sockaddr_in) -> u32 {
         ::ntoh((*sa).sin_addr.s_addr)
     }
+
+    pub fn in_addr_to_u32(addr: &in_addr) -> u32 {
+        ::ntoh(addr.s_addr)
+    }
 }
 
 pub struct Socket {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -42,6 +42,10 @@ pub mod c {
     pub fn sockaddr_in_u32(sa: &sockaddr_in) -> u32 {
         ::ntoh(unsafe { *sa.sin_addr.S_un.S_addr() })
     }
+
+    pub fn in_addr_to_u32(addr: &in_addr) -> u32 {
+        ::ntoh(unsafe { *addr.S_un.S_addr() })
+    }
 }
 
 use self::c::*;


### PR DESCRIPTION
This adds some options to UDPSocket for multicasting operations.

- `set_multicast_if_v4` for specifying the interface to use for ipv4 outbound multicast packets
- `set_multicast_if_v6` for specifying the interface (index) to use for ipv6 outbound multicast packets
- `set_multicast_hops_v6` the corollary to `set_multicast_ttl_v4`

Ready for commit requires: https://github.com/rust-lang/libc/pull/925
