### PR TITLE
Check only_v6 mode setting before trying to set it

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -844,7 +844,11 @@ impl TcpStreamExt for TcpStream {
     }
 
     fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+        if get_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY).map(int2bool)? != only_v6 {
+            set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+        } else {
+            Ok(())
+        }
     }
 
     fn only_v6(&self) -> io::Result<bool> {
@@ -1090,7 +1094,11 @@ impl UdpSocketExt for UdpSocket {
     }
 
     fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+        if get_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY).map(int2bool)? != only_v6 {
+            set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+        } else {
+            Ok(())
+        }
     }
 
     fn only_v6(&self) -> io::Result<bool> {
@@ -1374,7 +1382,11 @@ impl TcpListenerExt for TcpListener {
     }
 
     fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
-        set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+        if get_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY).map(int2bool)? != only_v6 {
+            set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+        } else {
+            Ok(())
+        }
     }
 
     fn only_v6(&self) -> io::Result<bool> {
@@ -1415,8 +1427,12 @@ impl TcpBuilder {
     ///
     /// [other]: trait.TcpStreamExt.html#tymethod.set_only_v6
     pub fn only_v6(&self, only_v6: bool) -> io::Result<&Self> {
-        set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
-            .map(|()| self)
+        if get_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY).map(int2bool)? != only_v6 {
+            set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+                .map(|()| self)
+        } else {
+            Ok(self)
+        }
     }
 
     /// Set value for the `SO_REUSEADDR` option on this socket.
@@ -1471,8 +1487,12 @@ impl UdpBuilder {
     ///
     /// [other]: struct.TcpBuilder.html#method.only_v6
     pub fn only_v6(&self, only_v6: bool) -> io::Result<&Self> {
-        set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
-            .map(|()| self)
+        if get_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY).map(int2bool)? != only_v6 {
+            set_opt(self.as_sock(), v(IPPROTO_IPV6), IPV6_V6ONLY, only_v6 as c_int)
+                .map(|()| self)
+        } else {
+            Ok(self)
+        }
     }
 
     /// Set value for the `SO_REUSEADDR` option on this socket.


### PR DESCRIPTION
Not all platforms allow changing a socket's IPV6_V6ONLY mode. OpenBSD for example treats this property as read-only, it is always enabled. It returns an error for any attempt to set it, even when you're setting it to what it already was. You are allowed to read out the value, though.

This PR changes the `only_v6`/`set_only_v6` functions so that they first check if the value is already what is desired, before attempting to set it. This allows the user to explicitly enable (or disable) IPV6_V6ONLY mode without having to worry about getting an error on some systems, as long as the default value for the system is the same as what is being requested. You only get an error when the system default is different, and unable to be changed.