### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/rust-lang-nursery/net2-rs.svg?branch=master)](https://travis-ci.org/rust-lang-nursery/net2-rs)
 [![Build status](https://ci.appveyor.com/api/projects/status/ns78f02jt2uvd2lp?svg=true)](https://ci.appveyor.com/project/alexcrichton/net2-rs)
 
-[Documentation](https://docs.rs/net2/0.2.32/net2/)
+[Documentation](https://docs.rs/net2/0.2.33/net2/)
 
 Extensions to the standard library's networking types, proposed in [RFC
 1158][rfc].


### PR DESCRIPTION
Current version is 0.2.33. Of course the version number will change again by this crate is published again, so feel free to close this PR and just update the version number on the next publish to whatever the new version number is :)