### PR TITLE
fixed wasi support (I think)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ winapi = { version = "0.3", features = ["handleapi", "winsock2", "ws2def", "ws2i
 [target.'cfg(any(target_os="redox", unix, target_os="wasi"))'.dependencies]
 libc = "0.2.54"
 
+[target.'cfg(target_os="wasi")'.dependencies]
+wasi = "0.9.0+wasi-snapshot-preview1"
+
 [dependencies]
 cfg-if = "0.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub use tcp::TcpBuilder;
 pub use udp::UdpBuilder;
 
 fn one_addr<T: ToSocketAddrs>(tsa: T) -> io::Result<SocketAddr> {
-    let mut addrs = try!(tsa.to_socket_addrs());
+    let mut addrs = tsa.to_socket_addrs()?;
     let addr = match addrs.next() {
         Some(addr) => addr,
         None => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,9 @@
 #[cfg(any(target_os = "redox", target_os = "wasi", unix))]
 extern crate libc;
 
+#[cfg(target_os = "wasi")]
+extern crate wasi;
+
 #[cfg(windows)]
 extern crate winapi;
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#[cfg(any(unix, target_os = "redox", target_os = "wasi"))]
+use libc::c_int;
 use std::fmt;
 use std::io;
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
-#[cfg(any(unix, target_os = "redox", target_os = "wasi"))]
-use libc::c_int;
 #[cfg(windows)]
 use winapi::ctypes::c_int;
 
@@ -26,36 +26,34 @@ pub struct Socket {
 
 impl Socket {
     pub fn new(family: c_int, ty: c_int) -> io::Result<Socket> {
-        Ok(Socket { inner: try!(sys::Socket::new(family, ty)) })
+        Ok(Socket {
+            inner: try!(sys::Socket::new(family, ty)),
+        })
     }
 
     pub fn bind(&self, addr: &SocketAddr) -> io::Result<()> {
         let (addr, len) = addr2raw(addr);
-        unsafe {
-            ::cvt(c::bind(self.inner.raw(), addr, len as c::socklen_t)).map(|_| ())
-        }
+        unsafe { ::cvt(c::bind(self.inner.raw(), addr, len as c::socklen_t)).map(|_| ()) }
     }
 
     pub fn listen(&self, backlog: i32) -> io::Result<()> {
-        unsafe {
-            ::cvt(c::listen(self.inner.raw(), backlog)).map(|_| ())
-        }
+        unsafe { ::cvt(c::listen(self.inner.raw(), backlog)).map(|_| ()) }
     }
 
     pub fn connect(&self, addr: &SocketAddr) -> io::Result<()> {
         let (addr, len) = addr2raw(addr);
-        unsafe {
-            ::cvt(c::connect(self.inner.raw(), addr, len)).map(|_| ())
-        }
+        unsafe { ::cvt(c::connect(self.inner.raw(), addr, len)).map(|_| ()) }
     }
 
     pub fn getsockname(&self) -> io::Result<SocketAddr> {
         unsafe {
             let mut storage: c::sockaddr_storage = mem::zeroed();
             let mut len = mem::size_of_val(&storage) as c::socklen_t;
-            try!(::cvt(c::getsockname(self.inner.raw(),
-                                      &mut storage as *mut _ as *mut _,
-                                      &mut len)));
+            try!(::cvt(c::getsockname(
+                self.inner.raw(),
+                &mut storage as *mut _ as *mut _,
+                &mut len
+            )));
             raw2addr(&storage, len)
         }
     }
@@ -69,7 +67,9 @@ impl fmt::Debug for Socket {
 
 impl ::AsInner for Socket {
     type Inner = sys::Socket;
-    fn as_inner(&self) -> &sys::Socket { &self.inner }
+    fn as_inner(&self) -> &sys::Socket {
+        &self.inner
+    }
 }
 
 impl ::FromInner for Socket {
@@ -81,62 +81,76 @@ impl ::FromInner for Socket {
 
 impl ::IntoInner for Socket {
     type Inner = sys::Socket;
-    fn into_inner(self) -> sys::Socket { self.inner }
+    fn into_inner(self) -> sys::Socket {
+        self.inner
+    }
 }
 
 fn addr2raw(addr: &SocketAddr) -> (*const c::sockaddr, c::socklen_t) {
     match *addr {
-        SocketAddr::V4(ref a) => {
-            (a as *const _ as *const _, mem::size_of_val(a) as c::socklen_t)
-        }
-        SocketAddr::V6(ref a) => {
-            (a as *const _ as *const _, mem::size_of_val(a) as c::socklen_t)
-        }
+        SocketAddr::V4(ref a) => (
+            a as *const _ as *const _,
+            mem::size_of_val(a) as c::socklen_t,
+        ),
+        SocketAddr::V6(ref a) => (
+            a as *const _ as *const _,
+            mem::size_of_val(a) as c::socklen_t,
+        ),
     }
 }
 
 fn raw2addr(storage: &c::sockaddr_storage, len: c::socklen_t) -> io::Result<SocketAddr> {
     match storage.ss_family as c_int {
-        c::AF_INET => {
-            unsafe {
-                assert!(len as usize >= mem::size_of::<c::sockaddr_in>());
-                let sa = storage as *const _ as *const c::sockaddr_in;
-                let bits = c::sockaddr_in_u32(&(*sa));
-                let ip = Ipv4Addr::new((bits >> 24) as u8,
-                                       (bits >> 16) as u8,
-                                       (bits >> 8) as u8,
-                                       bits as u8);
-                Ok(SocketAddr::V4(SocketAddrV4::new(ip, ::ntoh((*sa).sin_port))))
-            }
-        }
-        c::AF_INET6 => {
-            unsafe {
-                assert!(len as usize >= mem::size_of::<c::sockaddr_in6>());
+        c::AF_INET => unsafe {
+            assert!(len as usize >= mem::size_of::<c::sockaddr_in>());
+            let sa = storage as *const _ as *const c::sockaddr_in;
+            let bits = c::sockaddr_in_u32(&(*sa));
+            let ip = Ipv4Addr::new(
+                (bits >> 24) as u8,
+                (bits >> 16) as u8,
+                (bits >> 8) as u8,
+                bits as u8,
+            );
+            Ok(SocketAddr::V4(SocketAddrV4::new(
+                ip,
+                ::ntoh((*sa).sin_port),
+            )))
+        },
+        c::AF_INET6 => unsafe {
+            assert!(len as usize >= mem::size_of::<c::sockaddr_in6>());
 
-                let sa = storage as *const _ as *const c::sockaddr_in6;
-                #[cfg(windows)]      let arr = (*sa).sin6_addr.u.Byte();
-                #[cfg(not(windows))] let arr = (*sa).sin6_addr.s6_addr;
+            let sa = storage as *const _ as *const c::sockaddr_in6;
+            #[cfg(windows)]
+            let arr = (*sa).sin6_addr.u.Byte();
+            #[cfg(not(windows))]
+            let arr = (*sa).sin6_addr.s6_addr;
 
-                let ip = Ipv6Addr::new(
-                    (arr[0] as u16) << 8 | (arr[1] as u16),
-                    (arr[2] as u16) << 8 | (arr[3] as u16),
-                    (arr[4] as u16) << 8 | (arr[5] as u16),
-                    (arr[6] as u16) << 8 | (arr[7] as u16),
-                    (arr[8] as u16) << 8 | (arr[9] as u16),
-                    (arr[10] as u16) << 8 | (arr[11] as u16),
-                    (arr[12] as u16) << 8 | (arr[13] as u16),
-                    (arr[14] as u16) << 8 | (arr[15] as u16),
-                );
+            let ip = Ipv6Addr::new(
+                (arr[0] as u16) << 8 | (arr[1] as u16),
+                (arr[2] as u16) << 8 | (arr[3] as u16),
+                (arr[4] as u16) << 8 | (arr[5] as u16),
+                (arr[6] as u16) << 8 | (arr[7] as u16),
+                (arr[8] as u16) << 8 | (arr[9] as u16),
+                (arr[10] as u16) << 8 | (arr[11] as u16),
+                (arr[12] as u16) << 8 | (arr[13] as u16),
+                (arr[14] as u16) << 8 | (arr[15] as u16),
+            );
 
-                #[cfg(windows)]      let sin6_scope_id = *(*sa).u.sin6_scope_id();
-                #[cfg(not(windows))] let sin6_scope_id = (*sa).sin6_scope_id;
+            #[cfg(windows)]
+            let sin6_scope_id = *(*sa).u.sin6_scope_id();
+            #[cfg(not(windows))]
+            let sin6_scope_id = (*sa).sin6_scope_id;
 
-                Ok(SocketAddr::V6(SocketAddrV6::new(ip,
-                                                    ::ntoh((*sa).sin6_port),
-                                                    (*sa).sin6_flowinfo,
-                                                    sin6_scope_id)))
-            }
-        }
-        _ => Err(io::Error::new(io::ErrorKind::InvalidInput, "invalid argument")),
+            Ok(SocketAddr::V6(SocketAddrV6::new(
+                ip,
+                ::ntoh((*sa).sin6_port),
+                (*sa).sin6_flowinfo,
+                sin6_scope_id,
+            )))
+        },
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "invalid argument",
+        )),
     }
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -27,7 +27,7 @@ pub struct Socket {
 impl Socket {
     pub fn new(family: c_int, ty: c_int) -> io::Result<Socket> {
         Ok(Socket {
-            inner: try!(sys::Socket::new(family, ty)),
+            inner: sys::Socket::new(family, ty)?,
         })
     }
 
@@ -49,11 +49,11 @@ impl Socket {
         unsafe {
             let mut storage: c::sockaddr_storage = mem::zeroed();
             let mut len = mem::size_of_val(&storage) as c::socklen_t;
-            try!(::cvt(c::getsockname(
+            ::cvt(c::getsockname(
                 self.inner.raw(),
                 &mut storage as *mut _ as *mut _,
-                &mut len
-            )));
+                &mut len,
+            ))?;
             raw2addr(&storage, len)
         }
     }

--- a/src/sys/redox/impls.rs
+++ b/src/sys/redox/impls.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::unix::io::{FromRawFd, AsRawFd};
+use std::os::unix::io::{AsRawFd, FromRawFd};
 
-use {TcpBuilder, UdpBuilder, FromInner, AsInner};
 use socket::Socket;
 use sys;
+use {AsInner, FromInner, TcpBuilder, UdpBuilder};
 
 impl FromRawFd for TcpBuilder {
     unsafe fn from_raw_fd(fd: usize) -> TcpBuilder {

--- a/src/sys/redox/mod.rs
+++ b/src/sys/redox/mod.rs
@@ -8,12 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
+use libc::{self, c_int};
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::os::unix::io::FromRawFd;
-use libc::{self, c_int};
 
 mod impls;
 
@@ -44,7 +43,9 @@ impl Socket {
         }
     }
 
-    pub fn raw(&self) -> c_int { self.fd }
+    pub fn raw(&self) -> c_int {
+        self.fd
+    }
 
     fn into_fd(self) -> c_int {
         let fd = self.fd;

--- a/src/sys/unix/impls.rs
+++ b/src/sys/unix/impls.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::unix::io::{FromRawFd, AsRawFd};
 use libc::c_int;
+use std::os::unix::io::{AsRawFd, FromRawFd};
 
-use {TcpBuilder, UdpBuilder, FromInner, AsInner};
 use socket::Socket;
 use sys;
+use {AsInner, FromInner, TcpBuilder, UdpBuilder};
 
 impl FromRawFd for TcpBuilder {
     unsafe fn from_raw_fd(fd: c_int) -> TcpBuilder {

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -49,7 +49,7 @@ impl Socket {
                 Err(e) => return Err(e),
             }
 
-            let fd = try!(::cvt(libc::socket(family, ty, 0)));
+            let fd = ::cvt(libc::socket(family, ty, 0))?;
             ioctl(fd, FIOCLEX);
             Ok(Socket { fd: fd })
         }
@@ -60,7 +60,7 @@ impl Socket {
     #[cfg(any(target_os = "solaris", target_os = "emscripten"))]
     pub fn new(family: c_int, ty: c_int) -> io::Result<Socket> {
         unsafe {
-            let fd = try!(::cvt(libc::socket(family, ty, 0)));
+            let fd = ::cvt(libc::socket(family, ty, 0))?;
             libc::fcntl(fd, libc::FD_CLOEXEC);
             Ok(Socket { fd: fd })
         }

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -8,14 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
+use libc::{self, c_int};
+#[cfg(not(any(target_os = "solaris", target_os = "emscripten")))]
+use libc::{ioctl, FIOCLEX};
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::os::unix::io::FromRawFd;
-use libc::{self, c_int};
-#[cfg(not(any(target_os = "solaris", target_os = "emscripten")))]
-use libc::{ioctl, FIOCLEX};
 
 mod impls;
 
@@ -67,7 +66,9 @@ impl Socket {
         }
     }
 
-    pub fn raw(&self) -> c_int { self.fd }
+    pub fn raw(&self) -> c_int {
+        self.fd
+    }
 
     fn into_fd(self) -> c_int {
         let fd = self.fd;

--- a/src/sys/wasi/impls.rs
+++ b/src/sys/wasi/impls.rs
@@ -1,33 +1,33 @@
 use std::os::wasi::io::{AsRawFd, FromRawFd};
 
 use socket::Socket;
-use sys::{self, c::__wasi_fd_t};
+use sys::{self, c::Fd};
 use {AsInner, FromInner, TcpBuilder, UdpBuilder};
 
 impl FromRawFd for TcpBuilder {
-    unsafe fn from_raw_fd(fd: __wasi_fd_t) -> TcpBuilder {
+    unsafe fn from_raw_fd(fd: Fd) -> TcpBuilder {
         let sock = sys::Socket::from_inner(fd);
         TcpBuilder::from_inner(Socket::from_inner(sock))
     }
 }
 
 impl AsRawFd for TcpBuilder {
-    fn as_raw_fd(&self) -> __wasi_fd_t {
+    fn as_raw_fd(&self) -> Fd {
         // TODO: this unwrap() is very bad
-        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as __wasi_fd_t
+        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as Fd
     }
 }
 
 impl FromRawFd for UdpBuilder {
-    unsafe fn from_raw_fd(fd: __wasi_fd_t) -> UdpBuilder {
+    unsafe fn from_raw_fd(fd: Fd) -> UdpBuilder {
         let sock = sys::Socket::from_inner(fd);
         UdpBuilder::from_inner(Socket::from_inner(sock))
     }
 }
 
 impl AsRawFd for UdpBuilder {
-    fn as_raw_fd(&self) -> __wasi_fd_t {
+    fn as_raw_fd(&self) -> Fd {
         // TODO: this unwrap() is very bad
-        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as __wasi_fd_t
+        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as Fd
     }
 }

--- a/src/sys/wasi/impls.rs
+++ b/src/sys/wasi/impls.rs
@@ -1,8 +1,8 @@
-use std::os::wasi::io::{FromRawFd, AsRawFd};
+use std::os::wasi::io::{AsRawFd, FromRawFd};
 
-use {TcpBuilder, UdpBuilder, FromInner, AsInner};
 use socket::Socket;
 use sys::{self, c::__wasi_fd_t};
+use {AsInner, FromInner, TcpBuilder, UdpBuilder};
 
 impl FromRawFd for TcpBuilder {
     unsafe fn from_raw_fd(fd: __wasi_fd_t) -> TcpBuilder {

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -9,16 +9,18 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
-use libc::{self, __wasi_fd_t, c_int};
+use libc::c_int;
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::os::wasi::io::FromRawFd;
+use wasi::Fd;
 
 mod impls;
 
 pub mod c {
     pub use libc::*;
+    pub use wasi::Fd;
 
     pub type sa_family_t = u16;
     pub type socklen_t = u32;
@@ -113,27 +115,19 @@ pub mod c {
     }
 
     pub unsafe fn getsockname(
-        _socket: __wasi_fd_t,
+        _socket: Fd,
         _address: *mut sockaddr,
         _address_len: *mut socklen_t,
     ) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn connect(
-        _socket: __wasi_fd_t,
-        _address: *const sockaddr,
-        _len: socklen_t,
-    ) -> c_int {
+    pub unsafe fn connect(_socket: Fd, _address: *const sockaddr, _len: socklen_t) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn listen(_socket: __wasi_fd_t, _backlog: c_int) -> c_int {
+    pub unsafe fn listen(_socket: Fd, _backlog: c_int) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn bind(
-        _socket: __wasi_fd_t,
-        _address: *const sockaddr,
-        _address_len: socklen_t,
-    ) -> c_int {
+    pub unsafe fn bind(_socket: Fd, _address: *const sockaddr, _address_len: socklen_t) -> c_int {
         unimplemented!()
     }
 
@@ -147,7 +141,7 @@ pub mod c {
 }
 
 pub struct Socket {
-    fd: __wasi_fd_t,
+    fd: Fd,
 }
 
 impl Socket {
@@ -155,11 +149,11 @@ impl Socket {
         unimplemented!()
     }
 
-    pub fn raw(&self) -> libc::__wasi_fd_t {
+    pub fn raw(&self) -> Fd {
         self.fd
     }
 
-    fn into_fd(self) -> libc::__wasi_fd_t {
+    fn into_fd(self) -> Fd {
         let fd = self.fd;
         mem::forget(self);
         fd
@@ -179,8 +173,8 @@ impl Socket {
 }
 
 impl ::FromInner for Socket {
-    type Inner = libc::__wasi_fd_t;
-    fn from_inner(fd: libc::__wasi_fd_t) -> Socket {
+    type Inner = Fd;
+    fn from_inner(fd: Fd) -> Socket {
         Socket { fd: fd }
     }
 }

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
-use libc::{self, c_int, __wasi_fd_t};
+use libc::{self, __wasi_fd_t, c_int};
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
@@ -112,19 +112,28 @@ pub mod c {
         pub imr_interface: in_addr,
     }
 
-    pub unsafe fn getsockname(_socket: __wasi_fd_t, _address: *mut sockaddr,
-                    _address_len: *mut socklen_t) -> c_int {
+    pub unsafe fn getsockname(
+        _socket: __wasi_fd_t,
+        _address: *mut sockaddr,
+        _address_len: *mut socklen_t,
+    ) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn connect(_socket: __wasi_fd_t, _address: *const sockaddr,
-                _len: socklen_t) -> c_int {
+    pub unsafe fn connect(
+        _socket: __wasi_fd_t,
+        _address: *const sockaddr,
+        _len: socklen_t,
+    ) -> c_int {
         unimplemented!()
     }
     pub unsafe fn listen(_socket: __wasi_fd_t, _backlog: c_int) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn bind(_socket: __wasi_fd_t, _address: *const sockaddr,
-            _address_len: socklen_t) -> c_int {
+    pub unsafe fn bind(
+        _socket: __wasi_fd_t,
+        _address: *const sockaddr,
+        _address_len: socklen_t,
+    ) -> c_int {
         unimplemented!()
     }
 

--- a/src/sys/windows/impls.rs
+++ b/src/sys/windows/impls.rs
@@ -8,12 +8,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::os::windows::io::{FromRawSocket, RawSocket, AsRawSocket};
+use std::os::windows::io::{AsRawSocket, FromRawSocket, RawSocket};
 use winapi::um::winsock2::SOCKET;
 
-use {TcpBuilder, UdpBuilder, FromInner, AsInner};
 use socket::Socket;
 use sys;
+use {AsInner, FromInner, TcpBuilder, UdpBuilder};
 
 impl FromRawSocket for TcpBuilder {
     unsafe fn from_raw_socket(fd: RawSocket) -> TcpBuilder {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -9,13 +9,13 @@
 // except according to those terms.
 
 use std::cell::RefCell;
-use std::io;
-use std::net::{SocketAddr, ToSocketAddrs, TcpListener, TcpStream};
 use std::fmt;
+use std::io;
+use std::net::{SocketAddr, TcpListener, TcpStream, ToSocketAddrs};
 
-use IntoInner;
 use socket::Socket;
 use sys::c;
+use IntoInner;
 
 /// An "in progress" TCP socket which has not yet been connected or listened.
 ///
@@ -48,12 +48,14 @@ impl TcpBuilder {
     /// This function directly corresponds to the bind(2) function on Windows
     /// and Unix.
     pub fn bind<T>(&self, addr: T) -> io::Result<&TcpBuilder>
-        where T: ToSocketAddrs
+    where
+        T: ToSocketAddrs,
     {
         self.with_socket(|sock| {
             let addr = try!(::one_addr(addr));
             sock.bind(&addr)
-        }).map(|()| self)
+        })
+        .map(|()| self)
     }
 
     /// Mark a socket as ready to accept incoming connection requests using
@@ -65,11 +67,8 @@ impl TcpBuilder {
     /// An error will be returned if `listen` or `connect` has already been
     /// called on this builder.
     pub fn listen(&self, backlog: i32) -> io::Result<TcpListener> {
-        self.with_socket(|sock| {
-            sock.listen(backlog)
-        }).and_then(|()| {
-            self.to_tcp_listener()
-        })
+        self.with_socket(|sock| sock.listen(backlog))
+            .and_then(|()| self.to_tcp_listener())
     }
 
     /// Initiate a connection on this socket to the specified address.
@@ -80,17 +79,15 @@ impl TcpBuilder {
     /// An error will be returned if `listen` or `connect` has already been
     /// called on this builder.
     pub fn connect<T>(&self, addr: T) -> io::Result<TcpStream>
-        where T: ToSocketAddrs
+    where
+        T: ToSocketAddrs,
     {
         self.with_socket(|sock| {
-            let err = io::Error::new(io::ErrorKind::Other,
-                                     "no socket addresses resolved");
-            try!(addr.to_socket_addrs()).fold(Err(err), |prev, addr| {
-                prev.or_else(|_| sock.connect(&addr))
-            })
-        }).and_then(|()| {
-            self.to_tcp_stream()
+            let err = io::Error::new(io::ErrorKind::Other, "no socket addresses resolved");
+            try!(addr.to_socket_addrs())
+                .fold(Err(err), |prev, addr| prev.or_else(|_| sock.connect(&addr)))
         })
+        .and_then(|()| self.to_tcp_stream())
     }
 
     /// Converts this builder into a `TcpStream`
@@ -100,9 +97,14 @@ impl TcpBuilder {
     /// already been consumed from a successful call to `connect`, `listen`,
     /// etc.
     pub fn to_tcp_stream(&self) -> io::Result<TcpStream> {
-        self.socket.borrow_mut().take().map(|s| s.into_inner().into_tcp_stream())
-            .ok_or(io::Error::new(io::ErrorKind::Other,
-                                  "socket has already been consumed"))
+        self.socket
+            .borrow_mut()
+            .take()
+            .map(|s| s.into_inner().into_tcp_stream())
+            .ok_or(io::Error::new(
+                io::ErrorKind::Other,
+                "socket has already been consumed",
+            ))
     }
 
     /// Converts this builder into a `TcpListener`
@@ -112,10 +114,14 @@ impl TcpBuilder {
     /// already been consumed from a successful call to `connect`, `listen`,
     /// etc.
     pub fn to_tcp_listener(&self) -> io::Result<TcpListener> {
-        self.socket.borrow_mut().take()
+        self.socket
+            .borrow_mut()
+            .take()
             .map(|s| s.into_inner().into_tcp_listener())
-            .ok_or(io::Error::new(io::ErrorKind::Other,
-                                  "socket has already been consumed"))
+            .ok_or(io::Error::new(
+                io::ErrorKind::Other,
+                "socket has already been consumed",
+            ))
     }
 
     /// Returns the address of the local half of this TCP socket.
@@ -125,37 +131,49 @@ impl TcpBuilder {
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         match *self.socket.borrow() {
             Some(ref s) => s.getsockname(),
-            None => Err(io::Error::new(io::ErrorKind::Other,
-                                       "builder has already finished its socket")),
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "builder has already finished its socket",
+            )),
         }
     }
 
     fn with_socket<F>(&self, f: F) -> io::Result<()>
-        where F: FnOnce(&Socket) -> io::Result<()>
+    where
+        F: FnOnce(&Socket) -> io::Result<()>,
     {
         match *self.socket.borrow() {
             Some(ref s) => f(s),
-            None => Err(io::Error::new(io::ErrorKind::Other,
-                                       "builder has already finished its socket")),
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "builder has already finished its socket",
+            )),
         }
     }
 }
 
 impl fmt::Debug for TcpBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "TcpBuilder {{ socket: {:?} }}",
-               self.socket.borrow().as_ref().unwrap())
+        write!(
+            f,
+            "TcpBuilder {{ socket: {:?} }}",
+            self.socket.borrow().as_ref().unwrap()
+        )
     }
 }
 
 impl ::AsInner for TcpBuilder {
     type Inner = RefCell<Option<Socket>>;
-    fn as_inner(&self) -> &RefCell<Option<Socket>> { &self.socket }
+    fn as_inner(&self) -> &RefCell<Option<Socket>> {
+        &self.socket
+    }
 }
 
 impl ::FromInner for TcpBuilder {
     type Inner = Socket;
     fn from_inner(sock: Socket) -> TcpBuilder {
-        TcpBuilder { socket: RefCell::new(Some(sock)) }
+        TcpBuilder {
+            socket: RefCell::new(Some(sock)),
+        }
     }
 }

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -52,7 +52,7 @@ impl TcpBuilder {
         T: ToSocketAddrs,
     {
         self.with_socket(|sock| {
-            let addr = try!(::one_addr(addr));
+            let addr = ::one_addr(addr)?;
             sock.bind(&addr)
         })
         .map(|()| self)
@@ -84,7 +84,7 @@ impl TcpBuilder {
     {
         self.with_socket(|sock| {
             let err = io::Error::new(io::ErrorKind::Other, "no socket addresses resolved");
-            try!(addr.to_socket_addrs())
+            addr.to_socket_addrs()?
                 .fold(Err(err), |prev, addr| prev.or_else(|_| sock.connect(&addr)))
         })
         .and_then(|()| self.to_tcp_stream())

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -51,10 +51,10 @@ impl UdpBuilder {
     where
         T: ToSocketAddrs,
     {
-        try!(self.with_socket(|sock| {
-            let addr = try!(::one_addr(addr));
+        self.with_socket(|sock| {
+            let addr = ::one_addr(addr)?;
             sock.bind(&addr)
-        }));
+        })?;
         Ok(self
             .socket
             .borrow_mut()

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -13,9 +13,9 @@ use std::fmt;
 use std::io;
 use std::net::{ToSocketAddrs, UdpSocket};
 
-use IntoInner;
 use socket::Socket;
 use sys::c;
+use IntoInner;
 
 /// An "in progress" UDP socket which has not yet been connected.
 ///
@@ -48,42 +48,58 @@ impl UdpBuilder {
     /// This function directly corresponds to the bind(2) function on Windows
     /// and Unix.
     pub fn bind<T>(&self, addr: T) -> io::Result<UdpSocket>
-        where T: ToSocketAddrs
+    where
+        T: ToSocketAddrs,
     {
         try!(self.with_socket(|sock| {
             let addr = try!(::one_addr(addr));
             sock.bind(&addr)
         }));
-        Ok(self.socket.borrow_mut().take().unwrap().into_inner().into_udp_socket())
+        Ok(self
+            .socket
+            .borrow_mut()
+            .take()
+            .unwrap()
+            .into_inner()
+            .into_udp_socket())
     }
 
     fn with_socket<F>(&self, f: F) -> io::Result<()>
-        where F: FnOnce(&Socket) -> io::Result<()>
+    where
+        F: FnOnce(&Socket) -> io::Result<()>,
     {
         match *self.socket.borrow() {
             Some(ref s) => f(s),
-            None => Err(io::Error::new(io::ErrorKind::Other,
-                                       "builder has already finished its socket")),
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "builder has already finished its socket",
+            )),
         }
     }
 }
 
 impl fmt::Debug for UdpBuilder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "UdpBuilder {{ socket: {:?} }}",
-               self.socket.borrow().as_ref().unwrap())
+        write!(
+            f,
+            "UdpBuilder {{ socket: {:?} }}",
+            self.socket.borrow().as_ref().unwrap()
+        )
     }
 }
 
 impl ::AsInner for UdpBuilder {
     type Inner = RefCell<Option<Socket>>;
-    fn as_inner(&self) -> &RefCell<Option<Socket>> { &self.socket }
+    fn as_inner(&self) -> &RefCell<Option<Socket>> {
+        &self.socket
+    }
 }
 
 impl ::FromInner for UdpBuilder {
     type Inner = Socket;
     fn from_inner(sock: Socket) -> UdpBuilder {
-        UdpBuilder { socket: RefCell::new(Some(sock)) }
+        UdpBuilder {
+            socket: RefCell::new(Some(sock)),
+        }
     }
 }
-

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -3,8 +3,8 @@
 use std::io;
 use sys::c::{self, c_int};
 
-use {TcpBuilder, UdpBuilder};
 use ext::{self, AsSock};
+use {TcpBuilder, UdpBuilder};
 
 /// Unix-specific extensions for the `TcpBuilder` type in this library.
 pub trait UnixTcpBuilderExt {
@@ -21,13 +21,17 @@ pub trait UnixTcpBuilderExt {
 
 impl UnixTcpBuilderExt for TcpBuilder {
     fn reuse_port(&self, reuse: bool) -> io::Result<&Self> {
-        ext::set_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT,
-                    reuse as c_int).map(|()| self)
+        ext::set_opt(
+            self.as_sock(),
+            c::SOL_SOCKET,
+            c::SO_REUSEPORT,
+            reuse as c_int,
+        )
+        .map(|()| self)
     }
 
     fn get_reuse_port(&self) -> io::Result<bool> {
-        ext::get_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT)
-            .map(ext::int2bool)
+        ext::get_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT).map(ext::int2bool)
     }
 }
 
@@ -46,12 +50,16 @@ pub trait UnixUdpBuilderExt {
 
 impl UnixUdpBuilderExt for UdpBuilder {
     fn reuse_port(&self, reuse: bool) -> io::Result<&Self> {
-        ext::set_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT,
-                    reuse as c_int).map(|()| self)
+        ext::set_opt(
+            self.as_sock(),
+            c::SOL_SOCKET,
+            c::SO_REUSEPORT,
+            reuse as c_int,
+        )
+        .map(|()| self)
     }
 
     fn get_reuse_port(&self) -> io::Result<bool> {
-        ext::get_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT)
-            .map(ext::int2bool)
+        ext::get_opt(self.as_sock(), c::SOL_SOCKET, c::SO_REUSEPORT).map(ext::int2bool)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
 #[doc(hidden)]
 pub trait NetInt {
     fn from_be(i: Self) -> Self;
@@ -35,7 +34,6 @@ macro_rules! one {
 
 one! { i8 i16 i32 i64 isize u8 u16 u32 u64 usize }
 
-
 #[doc(hidden)]
 pub trait Zero {
     fn zero() -> Self;
@@ -48,4 +46,3 @@ macro_rules! zero {
 }
 
 zero! { i8 i16 i32 i64 isize u8 u16 u32 u64 usize }
-

--- a/tests/all.rs
+++ b/tests/all.rs
@@ -1,16 +1,18 @@
 extern crate net2;
 
-use std::net::{TcpStream, IpAddr, Ipv4Addr, Ipv6Addr};
 use std::io::prelude::*;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, TcpStream};
 use std::thread;
 
 use net2::TcpBuilder;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with: {}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with: {}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]
@@ -31,7 +33,7 @@ fn smoke_build_listener() {
     });
 
     let mut stream = t!(TcpStream::connect(&addr));
-    t!(stream.write(&[1,2,3]));
+    t!(stream.write(&[1, 2, 3]));
     t.join().unwrap();
 }
 


### PR DESCRIPTION
New to wasi, but I think these changes fix the build errors described in #92.

I likely missed/mis-implemented something, and I committed some `cargo fmt` changes + `deny` warnings as well, I can cherry-pick them out and make a new PR if necessary. The relevant changes are:
- adding [`wasi`](https://crates.io/crates/wasi) as a dependency
- replacing `__wasi_fd_t` with `wasi::Fd` in `sys::wasi::{mod,impl}.rs`
- updating `send` and `recv` to use `wasi::sock_send` and `wasi::sock_recv` in `ext.rs`, lines 1293 and 1346.

Feel free to let me know what to fix.