### PR TITLE
OpenBSD: Fix keepalive_ms and set_keepalive_ms.

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -738,24 +738,6 @@ impl TcpStreamExt for TcpStream {
         Ok(Some((secs as u32) * 1000))
     }
 
-    #[cfg(target_os = "openbsd")]
-    fn set_keepalive_ms(&self, keepalive: Option<u32>) -> io::Result<()> {
-        set_opt(self.as_sock(), SOL_SOCKET, SO_KEEPALIVE,
-                    keepalive.is_some() as c_int)?;
-        Ok(())
-    }
-
-    #[cfg(target_os = "openbsd")]
-    fn keepalive_ms(&self) -> io::Result<Option<u32>> {
-        let keepalive = get_opt::<c_int>(self.as_sock(), SOL_SOCKET,
-                                             SO_KEEPALIVE)?;
-        if keepalive == 0 {
-            return Ok(None)
-        } else {
-            return Ok(Some(1u32))
-        }
-    }
-
     #[cfg(all(unix, not(target_os = "openbsd")))]
     fn set_keepalive_ms(&self, keepalive: Option<u32>) -> io::Result<()> {
         try!(set_opt(self.as_sock(), SOL_SOCKET, SO_KEEPALIVE,
@@ -777,6 +759,24 @@ impl TcpStreamExt for TcpStream {
         let secs = try!(get_opt::<c_int>(self.as_sock(), v(IPPROTO_TCP),
                                         KEEPALIVE_OPTION));
         Ok(Some((secs as u32) * 1000))
+    }
+
+    #[cfg(target_os = "openbsd")]
+    fn set_keepalive_ms(&self, keepalive: Option<u32>) -> io::Result<()> {
+        set_opt(self.as_sock(), SOL_SOCKET, SO_KEEPALIVE,
+                    keepalive.is_some() as c_int)?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "openbsd")]
+    fn keepalive_ms(&self) -> io::Result<Option<u32>> {
+        let keepalive = get_opt::<c_int>(self.as_sock(), SOL_SOCKET,
+                                             SO_KEEPALIVE)?;
+        if keepalive == 0 {
+            return Ok(None)
+        } else {
+            return Ok(Some(1u32))
+        }
     }
 
     #[cfg(target_os = "wasi")]


### PR DESCRIPTION
OpenBSD (as of release 6.6) does not support the socket option `TCP_KEEPIDLE` ([tcp(4)](https://man.openbsd.org/OpenBSD-6.6/tcp.4)).  To be using `SO_KEEPALIVE` instead made it compile but was not correct and was failing at run-time.

This pull request fixes #82.  That github issue has a good description of the problem.

NetBSD supports the option ([tcp(4)](https://netbsd.gw.com/cgi-bin/man-cgi?tcp++NetBSD-9.0)) and NetBSD should therefore be treated like generic unix.  It therefore also did not seem right to use `SO_KEEPALIVE` as the `KEEPALIVE_OPTION` on NetBSD.

I have tested the patched `net2` as of f061e5e in combination with the http client in `hyper` version `=0.12.35`.  I have tested on OpenBSD 6.6 amd64 with `rustc 1.38.0`, on Linux x86_64 with `rustc 1.43.1` and on NetBSD 9.0 amd64 with `rustc 1.42.0`.