### PR TITLE
add illumos support

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -28,6 +28,7 @@ cfg_if! {
                  target_os = "netbsd",
                  target_os = "openbsd",
                  target_os = "solaris",
+                 target_os = "illumos",
                  target_env = "uclibc"))] {
         use libc::IPV6_JOIN_GROUP as IPV6_ADD_MEMBERSHIP;
         use libc::IPV6_LEAVE_GROUP as IPV6_DROP_MEMBERSHIP;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod utils;
 #[cfg(unix)] #[path = "sys/unix/mod.rs"] mod sys;
 #[cfg(windows)] #[path = "sys/windows/mod.rs"] mod sys;
 #[cfg(target_os = "wasi")] #[path = "sys/wasi/mod.rs"] mod sys;
-#[cfg(all(unix, not(any(target_os = "solaris"))))] pub mod unix;
+#[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))] pub mod unix;
 
 pub use tcp::TcpBuilder;
 pub use udp::UdpBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,10 @@
        html_root_url = "https://doc.rust-lang.org/net2-rs")]
 #![deny(missing_docs, warnings)]
 
+// Allow the use of the deprecated try! macro so that this still builds on newer
+// Rust compilers for now:
+#![allow(deprecated)]
+
 #![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
 #[cfg(any(target_os = "redox", target_os = "wasi", unix))] extern crate libc;

--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -14,7 +14,7 @@ use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
 use std::os::unix::io::FromRawFd;
 use libc::{self, c_int};
-#[cfg(not(any(target_os = "solaris", target_os = "emscripten")))]
+#[cfg(not(any(target_os = "solaris", target_os = "illumos", target_os = "emscripten")))]
 use libc::{ioctl, FIOCLEX};
 
 mod impls;
@@ -36,7 +36,7 @@ pub struct Socket {
 }
 
 impl Socket {
-    #[cfg(not(any(target_os = "solaris", target_os = "emscripten")))]
+    #[cfg(not(any(target_os = "solaris", target_os = "illumos", target_os = "emscripten")))]
     pub fn new(family: c_int, ty: c_int) -> io::Result<Socket> {
         unsafe {
             // Linux >2.6.26 overloads the type argument to accept SOCK_CLOEXEC,
@@ -56,9 +56,9 @@ impl Socket {
         }
     }
 
-    // ioctl(FIOCLEX) is not supported by Solaris/Illumos or emscripten,
+    // ioctl(FIOCLEX) is not supported by Solaris, illumos or emscripten,
     // use fcntl(FD_CLOEXEC) instead
-    #[cfg(any(target_os = "solaris", target_os = "emscripten"))]
+    #[cfg(any(target_os = "solaris", target_os = "illumos", target_os = "emscripten"))]
     pub fn new(family: c_int, ty: c_int) -> io::Result<Socket> {
         unsafe {
             let fd = try!(::cvt(libc::socket(family, ty, 0)));


### PR DESCRIPTION
Previously, illumos systems used the "x86_64-sun-solaris" host triple.
Now that we're getting an "x86_64-unknown-illumos" triple, we need to
add new target_os conditionals for illumos.

With this change I'd like to get a new version, 0.2.34, published to crates.io so that we can start using it in other repositories.  Thanks for taking a look!