### PR TITLE
Don't assume memory layout of std::net::SocketAddr

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -102,8 +102,8 @@ impl SocketAddrCRepr {
 
 fn addr2raw(addr: &SocketAddr) -> (SocketAddrCRepr, c::socklen_t) {
     match addr {
-        SocketAddr::V4(v4) => addr2raw_v4(v4),
-        SocketAddr::V6(v6) => addr2raw_v6(v6),
+        &SocketAddr::V4(ref v4) => addr2raw_v4(v4),
+        &SocketAddr::V6(ref v6) => addr2raw_v6(v6),
     }
 }
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -87,7 +87,7 @@ impl ::IntoInner for Socket {
 /// A type with the same memory layout as `c::sockaddr`. Used in converting Rust level
 /// SocketAddr* types into their system representation. The benefit of this specific
 /// type over using `c::sockaddr_storage` is that this type is exactly as large as it
-/// needs to be and not a lot larger. And it can be initialized cleaner from Rust.
+/// needs to be and not a lot larger.
 #[repr(C)]
 pub(crate) union SocketAddrCRepr {
     v4: c::sockaddr_in,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -109,10 +109,8 @@ fn addr2raw(addr: &SocketAddr) -> (SocketAddrCRepr, c::socklen_t) {
 
 #[cfg(unix)]
 fn addr2raw_v4(addr: &SocketAddrV4) -> (SocketAddrCRepr, c::socklen_t) {
-    // `s_addr` is stored as BE on all machines and the array is in BE order.
-    // So just transmuting the octects to the `u32` representation works.
     let sin_addr = c::in_addr {
-        s_addr: unsafe { mem::transmute::<_, u32>(addr.ip().octets()) },
+        s_addr: u32::from(*addr.ip()).to_be(),
     };
 
     let sockaddr = SocketAddrCRepr {
@@ -137,11 +135,9 @@ fn addr2raw_v4(addr: &SocketAddrV4) -> (SocketAddrCRepr, c::socklen_t) {
 
 #[cfg(windows)]
 fn addr2raw_v4(addr: &SocketAddrV4) -> (SocketAddrCRepr, c::socklen_t) {
-    // `S_un` is stored as BE on all machines and the array is in BE order.
-    // So just transmuting the octects to the `u32` representation works.
     let sin_addr = unsafe {
         let mut s_un = mem::zeroed::<c::in_addr_S_un>();
-        *s_un.S_addr_mut() = mem::transmute::<_, u32>(addr.ip().octets());
+        *s_un.S_addr_mut() = u32::from(*addr.ip()).to_be();
         c::IN_ADDR { S_un: s_un }
     };
 

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -137,9 +137,10 @@ fn addr2raw(addr: &SocketAddr) -> (SocketAddrCRepr, c::socklen_t) {
         }
         SocketAddr::V6(addr) => {
             #[cfg(unix)]
-            let sin6_addr = c::in6_addr {
-                s6_addr: addr.ip().octets(),
-                ..unsafe { mem::zeroed() }
+            let sin6_addr = {
+                let mut sin6_addr = unsafe { mem::zeroed::<c::in6_addr>() };
+                sin6_addr.s6_addr = addr.ip().octets();
+                sin6_addr
             };
             #[cfg(windows)]
             let sin6_addr = unsafe {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -34,6 +34,7 @@ pub mod c {
     pub use winapi::shared::ws2def::SOCKADDR as sockaddr;
     pub use winapi::shared::ws2def::SOCKADDR_STORAGE as sockaddr_storage;
     pub use winapi::shared::ws2def::SOCKADDR_IN as sockaddr_in;
+    pub use winapi::shared::ws2def::ADDRESS_FAMILY as sa_family_t;
     pub use winapi::shared::ws2ipdef::*;
     pub use winapi::shared::ws2ipdef::SOCKADDR_IN6_LH as sockaddr_in6;
     pub use winapi::shared::ws2ipdef::IP_MREQ as ip_mreq;


### PR DESCRIPTION
Fixes #105 

This crate assumes the memory layout of `std::net::SocketAddr`, something it should not do. The layout might be correct now, but it's not part of the contract `std` makes to the outside world. Having commonly used crates like this one depend on unspecified things like that makes it harder for `std` to evolve.

This PR changes that by correctly converting between the `std` representation and the system representation instead of just doing pointer casting.

Same kind of fix as was recently done in https://github.com/rust-lang/socket2-rs/pull/120 and https://github.com/tokio-rs/mio/pull/1388