### PR TITLE
haiku: Fix sockaddr_in/sockaddr_in6; Solves #108

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -118,14 +118,18 @@ fn addr2raw_v4(addr: &SocketAddrV4) -> (SocketAddrCRepr, c::socklen_t) {
             sin_family: c::AF_INET as c::sa_family_t,
             sin_port: addr.port().to_be(),
             sin_addr,
+            #[cfg(not(target_os = "haiku"))]
             sin_zero: [0; 8],
+            #[cfg(target_os = "haiku")]
+            sin_zero: [0; 24],
             #[cfg(any(
                 target_os = "dragonfly",
                 target_os = "freebsd",
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
-                target_os = "openbsd"
+                target_os = "openbsd",
+                target_os = "haiku",
             ))]
             sin_len: 0,
         },
@@ -173,7 +177,8 @@ fn addr2raw_v6(addr: &SocketAddrV6) -> (SocketAddrCRepr, c::socklen_t) {
                 target_os = "ios",
                 target_os = "macos",
                 target_os = "netbsd",
-                target_os = "openbsd"
+                target_os = "openbsd",
+                target_os = "haiku",
             ))]
             sin6_len: 0,
             #[cfg(any(target_os = "solaris", target_os = "illumos"))]


### PR DESCRIPTION
Bugfix only, solves final remaining build issues under Haiku (a new Rust platform)

```
/Data/Code/net2-rs> cargo test
   Compiling libc v0.2.81
   Compiling cfg-if v0.1.10
   Compiling net2 v0.2.36 (/Data/Code/net2-rs)
    Finished test [unoptimized + debuginfo] target(s) in 3.53s
     Running target/debug/deps/net2-11767bb81e44864e

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target/debug/deps/all-83c169dcd3ae1663

running 2 tests
test smoke_build_listener ... ok
test smoke_build_listener_v6 ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests net2

running 1 test
test src/lib.rs - (line 27) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
