### PR TITLE
On NetBSD, use TCP_KEEPIDLE as KEEPALIVE_OPTION.

### DIFF
--- a/src/ext.rs
+++ b/src/ext.rs
@@ -668,7 +668,7 @@ impl<T: AsRawSocket> AsSock for T {
 cfg_if! {
     if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         use libc::TCP_KEEPALIVE as KEEPALIVE_OPTION;
-    } else if #[cfg(any(target_os = "haiku", target_os = "netbsd", target_os = "openbsd"))] {
+    } else if #[cfg(any(target_os = "haiku",  target_os = "openbsd"))] {
         use libc::SO_KEEPALIVE as KEEPALIVE_OPTION;
     } else if #[cfg(unix)] {
         use libc::TCP_KEEPIDLE as KEEPALIVE_OPTION;


### PR DESCRIPTION
Without this, we saw this on NetBSD (routinator uses net2):

 13038     19 routinator CALL  setsockopt(0x15,0xffff,8,0x7d60bd3d62b4,4)
 13038     19 routinator RET   setsockopt 0
 13038     19 routinator CALL  setsockopt(0x15,6,8,0x7d60bd3d62b4,4)
 13038     19 routinator RET   setsockopt -1 errno 42 Protocol option not available

The '8' in the above corresponds to the "ifdef notyet" definition
of TCP_NOOPT, reserved for (future/possible) FreeBSD compat, and
results in the ENOPROTOOPT error return shown above.