### PR TITLE
Make the library compile for wasi again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ winapi = { version = "0.3", features = ["handleapi", "winsock2", "ws2def", "ws2i
 [target.'cfg(any(target_os="redox", unix, target_os="wasi"))'.dependencies]
 libc = "0.2.54"
 
+[target.'cfg(target_os="wasi")'.dependencies]
+wasi = "0.10.0+wasi-snapshot-preview1"
+
 [dependencies]
 cfg-if = "0.1"
 

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1218,8 +1218,8 @@ impl UdpSocketExt for UdpSocket {
     fn send(&self, buf: &[u8]) -> io::Result<usize> {
         let _so_datalen: *mut sys::c::size_t = &mut 0;
         unsafe {
-            let _errno = libc::__wasi_sock_send(
-                self.as_sock() as libc::__wasi_fd_t,
+            let _errno = wasi::wasi_snapshot_preview1::sock_send(
+                self.as_sock() as wasi::Fd,
                 buf.as_ptr() as *const _,
                 buf.len(),
                 0,
@@ -1259,9 +1259,9 @@ impl UdpSocketExt for UdpSocket {
     #[cfg(target_os = "wasi")]
     fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         let _ro_datalen: *mut sys::c::size_t = &mut 0;
-        let _ro_flags: *mut sys::c::__wasi_roflags_t = &mut 0;
+        let _ro_flags: *mut wasi::Roflags = &mut 0;
         unsafe {
-            let _errno = __wasi_sock_recv(
+            let _errno = wasi::wasi_snapshot_preview1::sock_recv(
                 self.as_sock(),
                 buf.as_mut_ptr() as *mut _,
                 buf.len(),

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -107,7 +107,7 @@ fn addr2raw(addr: &SocketAddr) -> (SocketAddrCRepr, c::socklen_t) {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 fn addr2raw_v4(addr: &SocketAddrV4) -> (SocketAddrCRepr, c::socklen_t) {
     let sin_addr = c::in_addr {
         s_addr: u32::from(*addr.ip()).to_be(),
@@ -156,7 +156,7 @@ fn addr2raw_v4(addr: &SocketAddrV4) -> (SocketAddrCRepr, c::socklen_t) {
     (sockaddr, mem::size_of::<c::sockaddr_in>() as c::socklen_t)
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 fn addr2raw_v6(addr: &SocketAddrV6) -> (SocketAddrCRepr, c::socklen_t) {
     let sin6_addr = {
         let mut sin6_addr = unsafe { mem::zeroed::<c::in6_addr>() };

--- a/src/sys/wasi/impls.rs
+++ b/src/sys/wasi/impls.rs
@@ -2,32 +2,32 @@ use std::os::wasi::io::{FromRawFd, AsRawFd};
 
 use {TcpBuilder, UdpBuilder, FromInner, AsInner};
 use socket::Socket;
-use sys::{self, c::__wasi_fd_t};
+use sys;
 
 impl FromRawFd for TcpBuilder {
-    unsafe fn from_raw_fd(fd: __wasi_fd_t) -> TcpBuilder {
+    unsafe fn from_raw_fd(fd: wasi::Fd) -> TcpBuilder {
         let sock = sys::Socket::from_inner(fd);
         TcpBuilder::from_inner(Socket::from_inner(sock))
     }
 }
 
 impl AsRawFd for TcpBuilder {
-    fn as_raw_fd(&self) -> __wasi_fd_t {
+    fn as_raw_fd(&self) -> wasi::Fd {
         // TODO: this unwrap() is very bad
-        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as __wasi_fd_t
+        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as wasi::Fd
     }
 }
 
 impl FromRawFd for UdpBuilder {
-    unsafe fn from_raw_fd(fd: __wasi_fd_t) -> UdpBuilder {
+    unsafe fn from_raw_fd(fd: wasi::Fd) -> UdpBuilder {
         let sock = sys::Socket::from_inner(fd);
         UdpBuilder::from_inner(Socket::from_inner(sock))
     }
 }
 
 impl AsRawFd for UdpBuilder {
-    fn as_raw_fd(&self) -> __wasi_fd_t {
+    fn as_raw_fd(&self) -> wasi::Fd {
         // TODO: this unwrap() is very bad
-        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as __wasi_fd_t
+        self.as_inner().borrow().as_ref().unwrap().as_inner().raw() as wasi::Fd
     }
 }

--- a/src/sys/wasi/mod.rs
+++ b/src/sys/wasi/mod.rs
@@ -9,7 +9,7 @@
 // except according to those terms.
 
 #![allow(non_camel_case_types)]
-use libc::{self, c_int, __wasi_fd_t};
+use libc::c_int;
 use std::io;
 use std::mem;
 use std::net::{TcpListener, TcpStream, UdpSocket};
@@ -66,6 +66,7 @@ pub mod c {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct sockaddr_in6 {
         pub sin6_family: sa_family_t,
         pub sin6_port: in_port_t,
@@ -75,6 +76,7 @@ pub mod c {
     }
 
     #[repr(C)]
+    #[derive(Copy, Clone)]
     pub struct sockaddr_in {
         pub sin_family: sa_family_t,
         pub sin_port: in_port_t,
@@ -112,18 +114,18 @@ pub mod c {
         pub imr_interface: in_addr,
     }
 
-    pub unsafe fn getsockname(_socket: __wasi_fd_t, _address: *mut sockaddr,
+    pub unsafe fn getsockname(_socket: wasi::Fd, _address: *mut sockaddr,
                     _address_len: *mut socklen_t) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn connect(_socket: __wasi_fd_t, _address: *const sockaddr,
+    pub unsafe fn connect(_socket: wasi::Fd, _address: *const sockaddr,
                 _len: socklen_t) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn listen(_socket: __wasi_fd_t, _backlog: c_int) -> c_int {
+    pub unsafe fn listen(_socket: wasi::Fd, _backlog: c_int) -> c_int {
         unimplemented!()
     }
-    pub unsafe fn bind(_socket: __wasi_fd_t, _address: *const sockaddr,
+    pub unsafe fn bind(_socket: wasi::Fd, _address: *const sockaddr,
             _address_len: socklen_t) -> c_int {
         unimplemented!()
     }
@@ -138,7 +140,7 @@ pub mod c {
 }
 
 pub struct Socket {
-    fd: __wasi_fd_t,
+    fd: wasi::Fd,
 }
 
 impl Socket {
@@ -146,11 +148,11 @@ impl Socket {
         unimplemented!()
     }
 
-    pub fn raw(&self) -> libc::__wasi_fd_t {
+    pub fn raw(&self) -> wasi::Fd {
         self.fd
     }
 
-    fn into_fd(self) -> libc::__wasi_fd_t {
+    fn into_fd(self) -> wasi::Fd {
         let fd = self.fd;
         mem::forget(self);
         fd
@@ -170,8 +172,8 @@ impl Socket {
 }
 
 impl ::FromInner for Socket {
-    type Inner = libc::__wasi_fd_t;
-    fn from_inner(fd: libc::__wasi_fd_t) -> Socket {
+    type Inner = wasi::Fd;
+    fn from_inner(fd: wasi::Fd) -> Socket {
         Socket { fd: fd }
     }
 }


### PR DESCRIPTION
This PR fixes the compilation errors that arise when doing `cargo build --target=wasm32-wasi`.
