### PR TITLE
Add support for QNX Neutrino

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ include = [
 winapi = { version = "0.3", features = ["handleapi", "winsock2", "ws2def", "ws2ipdef", "ws2tcpip"] }
 
 [target.'cfg(any(unix, target_os="wasi"))'.dependencies]
-libc = "0.2.54"
+libc = "0.2.139"
 
 [dependencies]
 cfg-if = "0.1"

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -130,6 +130,7 @@ fn addr2raw_v4(addr: &SocketAddrV4) -> (SocketAddrCRepr, c::socklen_t) {
                 target_os = "netbsd",
                 target_os = "openbsd",
                 target_os = "haiku",
+                target_os = "nto",
             ))]
             sin_len: 0,
         },
@@ -179,6 +180,7 @@ fn addr2raw_v6(addr: &SocketAddrV6) -> (SocketAddrCRepr, c::socklen_t) {
                 target_os = "netbsd",
                 target_os = "openbsd",
                 target_os = "haiku",
+                target_os = "nto",
             ))]
             sin6_len: 0,
             #[cfg(any(target_os = "solaris", target_os = "illumos"))]


### PR DESCRIPTION
This adds support for QNX Neutrino 7.1 (https://blackberry.qnx.com/en/products/foundation-software/qnx-rtos). This is helpful for crates which still depend on net2-rs.